### PR TITLE
fix: fix language code and remove color space.

### DIFF
--- a/src/ShaderAssets/Blendings/ClipAddition.ttblend
+++ b/src/ShaderAssets/Blendings/ClipAddition.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/Addition
-KeyName ja クリスタ/加算-覆い焼き(リニア)
+KeyName ja-JP クリスタ/加算-覆い焼き(リニア)
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipAdditionGlow.ttblend
+++ b/src/ShaderAssets/Blendings/ClipAdditionGlow.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/AdditionGlow
-KeyName ja クリスタ/加算(発光)
+KeyName ja-JP クリスタ/加算(発光)
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipColor.ttblend
+++ b/src/ShaderAssets/Blendings/ClipColor.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/Color
-KeyName ja クリスタ/カラー
+KeyName ja-JP クリスタ/カラー
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipColorBurn.ttblend
+++ b/src/ShaderAssets/Blendings/ClipColorBurn.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/ColorBurn
-KeyName ja クリスタ/焼きこみカラー
+KeyName ja-JP クリスタ/焼きこみカラー
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipColorDodge.ttblend
+++ b/src/ShaderAssets/Blendings/ClipColorDodge.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/ColorDodge
-KeyName ja クリスタ/覆い焼カラー
+KeyName ja-JP クリスタ/覆い焼カラー
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipColorDodgeGlow.ttblend
+++ b/src/ShaderAssets/Blendings/ClipColorDodgeGlow.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/ColorDodgeGlow
-KeyName ja クリスタ/覆い焼き発光
+KeyName ja-JP クリスタ/覆い焼き発光
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipDarkenColorOnly.ttblend
+++ b/src/ShaderAssets/Blendings/ClipDarkenColorOnly.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/DarkenColorOnly
-KeyName ja クリスタ/カラー比較(暗)
+KeyName ja-JP クリスタ/カラー比較(暗)
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipDarkenOnly.ttblend
+++ b/src/ShaderAssets/Blendings/ClipDarkenOnly.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/DarkenOnly
-KeyName ja クリスタ/比較(暗)
+KeyName ja-JP クリスタ/比較(暗)
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipDifference.ttblend
+++ b/src/ShaderAssets/Blendings/ClipDifference.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/Difference
-KeyName ja クリスタ/差の絶対値
+KeyName ja-JP クリスタ/差の絶対値
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipDivide.ttblend
+++ b/src/ShaderAssets/Blendings/ClipDivide.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/Divide
-KeyName ja クリスタ/除算
+KeyName ja-JP クリスタ/除算
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipExclusion.ttblend
+++ b/src/ShaderAssets/Blendings/ClipExclusion.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/Exclusion
-KeyName ja クリスタ/除外
+KeyName ja-JP クリスタ/除外
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipHardLight.ttblend
+++ b/src/ShaderAssets/Blendings/ClipHardLight.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/HardLight
-KeyName ja クリスタ/ハードライト
+KeyName ja-JP クリスタ/ハードライト
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipHardMix.ttblend
+++ b/src/ShaderAssets/Blendings/ClipHardMix.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/HardMix
-KeyName ja クリスタ/ハードミックス
+KeyName ja-JP クリスタ/ハードミックス
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipHue.ttblend
+++ b/src/ShaderAssets/Blendings/ClipHue.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/Hue
-KeyName ja クリスタ/色相
+KeyName ja-JP クリスタ/色相
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipLightenColorOnly.ttblend
+++ b/src/ShaderAssets/Blendings/ClipLightenColorOnly.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/LightenColorOnly
-KeyName ja クリスタ/カラー比較(明)
+KeyName ja-JP クリスタ/カラー比較(明)
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipLightenOnly.ttblend
+++ b/src/ShaderAssets/Blendings/ClipLightenOnly.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/LightenOnly
-KeyName ja クリスタ/比較(明)
+KeyName ja-JP クリスタ/比較(明)
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipLinearBurn.ttblend
+++ b/src/ShaderAssets/Blendings/ClipLinearBurn.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/LinearBurn
-KeyName ja クリスタ/焼きこみ(リニア)
+KeyName ja-JP クリスタ/焼きこみ(リニア)
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipLinearLight.ttblend
+++ b/src/ShaderAssets/Blendings/ClipLinearLight.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/LinearLight
-KeyName ja クリスタ/リニアライト
+KeyName ja-JP クリスタ/リニアライト
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipLuminosity.ttblend
+++ b/src/ShaderAssets/Blendings/ClipLuminosity.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/Luminosity
-KeyName ja クリスタ/輝度
+KeyName ja-JP クリスタ/輝度
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipMul.ttblend
+++ b/src/ShaderAssets/Blendings/ClipMul.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/Mul
-KeyName ja クリスタ/乗算
+KeyName ja-JP クリスタ/乗算
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipNormal.ttblend
+++ b/src/ShaderAssets/Blendings/ClipNormal.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/Normal
-KeyName ja クリスタ/通常
+KeyName ja-JP クリスタ/通常
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipOverlay.ttblend
+++ b/src/ShaderAssets/Blendings/ClipOverlay.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/Overlay
-KeyName ja クリスタ/オーバーレイ
+KeyName ja-JP クリスタ/オーバーレイ
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipPinLight.ttblend
+++ b/src/ShaderAssets/Blendings/ClipPinLight.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/PinLight
-KeyName ja クリスタ/ピンライト
+KeyName ja-JP クリスタ/ピンライト
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipSaturation.ttblend
+++ b/src/ShaderAssets/Blendings/ClipSaturation.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/Saturation
-KeyName ja クリスタ/彩度
+KeyName ja-JP クリスタ/彩度
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipScreen.ttblend
+++ b/src/ShaderAssets/Blendings/ClipScreen.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/Screen
-KeyName ja クリスタ/スクリーン
+KeyName ja-JP クリスタ/スクリーン
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipSoftLight.ttblend
+++ b/src/ShaderAssets/Blendings/ClipSoftLight.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/SoftLight
-KeyName ja クリスタ/ソフトライト
+KeyName ja-JP クリスタ/ソフトライト
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipSubtract.ttblend
+++ b/src/ShaderAssets/Blendings/ClipSubtract.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/Subtract
-KeyName ja クリスタ/減算
+KeyName ja-JP クリスタ/減算
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ClipVividLight.ttblend
+++ b/src/ShaderAssets/Blendings/ClipVividLight.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Clip/VividLight
-KeyName ja クリスタ/ビビッドライト
+KeyName ja-JP クリスタ/ビビッドライト
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ExtraColorBlending/AlphaAddition.ttblend
+++ b/src/ShaderAssets/Blendings/ExtraColorBlending/AlphaAddition.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key ExtraColorBlending/AlphaOperator/AlphaAddition
-KeyName ja 拡張色合成/アルファ演算/アルファ加算
+KeyName ja-JP 拡張色合成/アルファ演算/アルファ加算
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ExtraColorBlending/AlphaDivision.ttblend
+++ b/src/ShaderAssets/Blendings/ExtraColorBlending/AlphaDivision.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key ExtraColorBlending/AlphaOperator/AlphaDivision
-KeyName ja 拡張色合成/アルファ演算/アルファ除算
+KeyName ja-JP 拡張色合成/アルファ演算/アルファ除算
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ExtraColorBlending/AlphaMultiply.ttblend
+++ b/src/ShaderAssets/Blendings/ExtraColorBlending/AlphaMultiply.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key ExtraColorBlending/AlphaOperator/AlphaMultiply
-KeyName ja 拡張色合成/アルファ演算/アルファ乗算
+KeyName ja-JP 拡張色合成/アルファ演算/アルファ乗算
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ExtraColorBlending/AlphaReplace.ttblend
+++ b/src/ShaderAssets/Blendings/ExtraColorBlending/AlphaReplace.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key ExtraColorBlending/AlphaOperator/AlphaReplace
-KeyName ja 拡張色合成/アルファ演算/アルファ置き換え
+KeyName ja-JP 拡張色合成/アルファ演算/アルファ置き換え
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ExtraColorBlending/AlphaSubtract.ttblend
+++ b/src/ShaderAssets/Blendings/ExtraColorBlending/AlphaSubtract.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key ExtraColorBlending/AlphaOperator/AlphaSubtract
-KeyName ja 拡張色合成/アルファ演算/アルファ減算
+KeyName ja-JP 拡張色合成/アルファ演算/アルファ減算
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/ExtraColorBlending/ColorReplace.ttblend
+++ b/src/ShaderAssets/Blendings/ExtraColorBlending/ColorReplace.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key ExtraColorBlending/ColorReplace
-KeyName ja 拡張色合成/カラー置き換え
+KeyName ja-JP 拡張色合成/カラー置き換え
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdAddition.ttblend
+++ b/src/ShaderAssets/Blendings/StdAddition.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Addition
-KeyName ja 加算-覆い焼き(リニア)
+KeyName ja-JP 加算-覆い焼き(リニア)
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdAdditionGlow.ttblend
+++ b/src/ShaderAssets/Blendings/StdAdditionGlow.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key AdditionGlow
-KeyName ja 加算発光
+KeyName ja-JP 加算発光
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdColor.ttblend
+++ b/src/ShaderAssets/Blendings/StdColor.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Color
-KeyName ja カラー
+KeyName ja-JP カラー
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdColorBurn.ttblend
+++ b/src/ShaderAssets/Blendings/StdColorBurn.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key ColorBurn
-KeyName ja 焼きこみカラー
+KeyName ja-JP 焼きこみカラー
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdColorDodge.ttblend
+++ b/src/ShaderAssets/Blendings/StdColorDodge.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key ColorDodge
-KeyName ja 覆い焼カラー
+KeyName ja-JP 覆い焼カラー
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdColorDodgeGlow.ttblend
+++ b/src/ShaderAssets/Blendings/StdColorDodgeGlow.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key ColorDodgeGlow
-KeyName ja 覆い焼き発光
+KeyName ja-JP 覆い焼き発光
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdDarkenColorOnly.ttblend
+++ b/src/ShaderAssets/Blendings/StdDarkenColorOnly.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key DarkenColorOnly
-KeyName ja カラー比較(暗)
+KeyName ja-JP カラー比較(暗)
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdDarkenOnly.ttblend
+++ b/src/ShaderAssets/Blendings/StdDarkenOnly.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key DarkenOnly
-KeyName ja 比較(暗)
+KeyName ja-JP 比較(暗)
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdDifference.ttblend
+++ b/src/ShaderAssets/Blendings/StdDifference.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Difference
-KeyName ja 差の絶対値
+KeyName ja-JP 差の絶対値
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdDissolve.ttblend
+++ b/src/ShaderAssets/Blendings/StdDissolve.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Dissolve
-KeyName ja ディザ合成
+KeyName ja-JP ディザ合成
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdDivide.ttblend
+++ b/src/ShaderAssets/Blendings/StdDivide.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Divide
-KeyName ja 除算
+KeyName ja-JP 除算
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdExclusion.ttblend
+++ b/src/ShaderAssets/Blendings/StdExclusion.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Exclusion
-KeyName ja 除外
+KeyName ja-JP 除外
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdHardLight.ttblend
+++ b/src/ShaderAssets/Blendings/StdHardLight.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key HardLight
-KeyName ja ハードライト
+KeyName ja-JP ハードライト
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdHardMix.ttblend
+++ b/src/ShaderAssets/Blendings/StdHardMix.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key HardMix
-KeyName ja ハードミックス
+KeyName ja-JP ハードミックス
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdHue.ttblend
+++ b/src/ShaderAssets/Blendings/StdHue.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Hue
-KeyName ja 色相
+KeyName ja-JP 色相
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdLightenColorOnly.ttblend
+++ b/src/ShaderAssets/Blendings/StdLightenColorOnly.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key LightenColorOnly
-KeyName ja カラー比較(明)
+KeyName ja-JP カラー比較(明)
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdLightenOnly.ttblend
+++ b/src/ShaderAssets/Blendings/StdLightenOnly.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key LightenOnly
-KeyName ja 比較(明)
+KeyName ja-JP 比較(明)
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdLinearBurn.ttblend
+++ b/src/ShaderAssets/Blendings/StdLinearBurn.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key LinearBurn
-KeyName ja 焼きこみ
+KeyName ja-JP 焼きこみ
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdLinearLight.ttblend
+++ b/src/ShaderAssets/Blendings/StdLinearLight.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key LinearLight
-KeyName ja リニアライト
+KeyName ja-JP リニアライト
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdLuminosity.ttblend
+++ b/src/ShaderAssets/Blendings/StdLuminosity.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Luminosity
-KeyName ja 輝度
+KeyName ja-JP 輝度
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdMul.ttblend
+++ b/src/ShaderAssets/Blendings/StdMul.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Mul
-KeyName ja 乗算
+KeyName ja-JP 乗算
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdNormal.ttblend
+++ b/src/ShaderAssets/Blendings/StdNormal.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Normal
-KeyName ja 通常
+KeyName ja-JP 通常
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdNotBlend.ttblend
+++ b/src/ShaderAssets/Blendings/StdNotBlend.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key NotBlend
-KeyName ja 合成なし
+KeyName ja-JP 合成なし
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdOverlay.ttblend
+++ b/src/ShaderAssets/Blendings/StdOverlay.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Overlay
-KeyName ja オーバーレイ
+KeyName ja-JP オーバーレイ
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdPinLight.ttblend
+++ b/src/ShaderAssets/Blendings/StdPinLight.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key PinLight
-KeyName ja ピンライト
+KeyName ja-JP ピンライト
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdSaturation.ttblend
+++ b/src/ShaderAssets/Blendings/StdSaturation.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Saturation
-KeyName ja 彩度
+KeyName ja-JP 彩度
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdScreen.ttblend
+++ b/src/ShaderAssets/Blendings/StdScreen.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Screen
-KeyName ja スクリーン
+KeyName ja-JP スクリーン
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdSoftLight.ttblend
+++ b/src/ShaderAssets/Blendings/StdSoftLight.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key SoftLight
-KeyName ja ソフトライト
+KeyName ja-JP ソフトライト
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdSubtract.ttblend
+++ b/src/ShaderAssets/Blendings/StdSubtract.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key Subtract
-KeyName ja 除算
+KeyName ja-JP 除算
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/Blendings/StdVividLight.ttblend
+++ b/src/ShaderAssets/Blendings/StdVividLight.ttblend
@@ -6,10 +6,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
+
 
 Key VividLight
-KeyName ja ビビッドライト
+KeyName ja-JP ビビッドライト
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/GrabBlend/Colorize.ttcomp
+++ b/src/ShaderAssets/GrabBlend/Colorize.ttcomp
@@ -6,7 +6,7 @@ LanguageVersion 2018
 
 TTComputeType GrabBlend
 
-ColorSpace Gamma
+
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/GrabBlend/HSLAdjustment.ttcomp
+++ b/src/ShaderAssets/GrabBlend/HSLAdjustment.ttcomp
@@ -6,7 +6,7 @@ LanguageVersion 2018
 
 TTComputeType GrabBlend
 
-ColorSpace Gamma
+
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/GrabBlend/HSVAdjustment.ttcomp
+++ b/src/ShaderAssets/GrabBlend/HSVAdjustment.ttcomp
@@ -6,7 +6,7 @@ LanguageVersion 2018
 
 TTComputeType GrabBlend
 
-ColorSpace Gamma
+
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/GrabBlend/LevelAdjustment.ttcomp
+++ b/src/ShaderAssets/GrabBlend/LevelAdjustment.ttcomp
@@ -6,7 +6,7 @@ LanguageVersion 2018
 
 TTComputeType GrabBlend
 
-ColorSpace Gamma
+
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/GrabBlend/LuminanceMapping.ttcomp
+++ b/src/ShaderAssets/GrabBlend/LuminanceMapping.ttcomp
@@ -6,7 +6,7 @@ LanguageVersion 2018
 
 TTComputeType GrabBlend
 
-ColorSpace Gamma
+
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/GrabBlend/SelectiveColorAdjustment.ttcomp
+++ b/src/ShaderAssets/GrabBlend/SelectiveColorAdjustment.ttcomp
@@ -6,7 +6,7 @@ LanguageVersion 2018
 
 TTComputeType GrabBlend
 
-ColorSpace Gamma
+
 
 END__TT_COMPUTE_SHADER_HEADER
 */

--- a/src/ShaderAssets/TTComputeShader-Spec.md
+++ b/src/ShaderAssets/TTComputeShader-Spec.md
@@ -125,8 +125,6 @@ TTComputeType General
 
 TexTransTool 内部で GrabBlend と呼ばれている物を記述するための存在、基本的にはただのコンピュートシェーダー。
 
-必須情報として下記 [ColorSpace](#colorspace) が必要になること以外は General と同じ。
-
 ## TT-Blending
 
 TexTransTool の 合成モードを追加できる仕組みでもある。
@@ -149,12 +147,10 @@ LanguageVersion 2018
 
 TTComputeType Blending
 
-ColorSpace Gamma
-
 Key SampleBlend/SimpleAdded
 
-KeyName en SampleBlend/SimpleAdded
-KeyName ja サンプルブレンド/シンプル加算
+KeyName en-US SampleBlend/SimpleAdded
+KeyName ja-JP サンプルブレンド/シンプル加算
 
 END__TT_COMPUTE_SHADER_HEADER
 */
@@ -169,23 +165,6 @@ float4 ColorBlend(float4 BaseColor, float4 AddColor)
 ### 追加の必須情報
 
 Blending として使用するために必要な追加の必須情報です。
-
-#### ColorSpace
-
-引数や戻り値の色空間を指定する存在です。
-
-example
-
-```text
-ColorSpace Gamma
-```
-
-選択肢はこれらが使用できます。
-
-- `Gamma`
-- `Linear`
-
-`Gamma` というのはいわゆる sRGB です。
 
 #### Key
 
@@ -211,16 +190,16 @@ TexTransTool デフォルトの物以外の場合は、この階層が必ず 1�
 TexTransTool 内で インスペクターに表示する場合の表示名を変更できる存在です。
 
 ```text
-KeyName en SampleBlend/SimpleAdded
-KeyName ja サンプルブレンド/シンプル加算
+KeyName en-US SampleBlend/SimpleAdded
+KeyName ja-JP サンプルブレンド/シンプル加算
 ```
 
 この KeyName の場合に限り Value の中身の扱いが少し変わり、Value の開始から一つ目の 空白 までは LanguageCode として扱い、その先を KeyName の Value つまり表示名という扱いになります。
 
 LanguageCode の選択肢
 
-- ja
-- en
+- ja-JP
+- en-US
 
 これは TexTransTool の言語設定に基づいていて、今後増える可能性もあります。
 それぞれの言語にて、定義されていない場合は [Key](#key) にフォールバックされるので気を付けましょう。


### PR DESCRIPTION
related https://github.com/ReinaS-64892/TexTransTool/pull/1014


TTT 本体のローカライズ関連の設定値の持ち方が変わったのもありそれに追従の形を取る。

それと ガンマ などの空間というを以前と違いまともに扱っていないため消し、そもそも色合成の関数に色空間は定義させない。

少なくとも現状は